### PR TITLE
SOE-2310: add 'update_non_existent' => 'delete',

### DIFF
--- a/modules/stanford_opportunity_importer/stanford_opportunity_importer.feeds_importer_default.inc
+++ b/modules/stanford_opportunity_importer/stanford_opportunity_importer.feeds_importer_default.inc
@@ -316,7 +316,7 @@ function stanford_opportunity_importer_feeds_importer_default() {
         ),
         'insert_new' => '1',
         'update_existing' => '2',
-        'update_non_existent' => 'skip',
+        'update_non_existent' => 'delete',
         'input_format' => 'filtered_html',
         'skip_hash_check' => 0,
         'bundle' => 'stanford_opportunity',


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- This changes the default action when importing non-existent nodes in the feed. Previously, these nodes were kept, now they are deleted.

# Needed By (Date)
- Sprint end

# Criticality
- Client is eagerly awaiting this.
- Fixes broken stuff

# Steps to Test
- Count the number of Opportunity nodes:
``` $ drush sqlq "select count(*) from field_data_field_s_opp_id" count(*)```
- Switch to this branch: 
```$ git checkout 7.x-1.x-delete-nodes```
- May need to revert feature 
  Verify first:
```  $ drush fd stanford_opportunity_importer ```
  (or navigate to **/admin/structure/features/stanford_opportunity_importer**)
``` $ drush fr stanford_opportunity_importer -y --force```
  (or revert at: **/admin/structure/features/stanford_opportunity_importer**)
- Navigate to **/admin/structure/feeds/stanford_opportunity_helper/settings/FeedsNodeProcessor**
- Verify that **Delete non-existent nodes** is selected (see [screenshot](https://stanfordits.atlassian.net/secure/attachment/37359/Screen%20Shot%202017-11-02%20at%2018.07.50.png))
- Navigate to **/engineering-opportunities-importer**
- Click on the **Import** tab
- Count the number of Opportunity nodes:
``` $ drush sqlq "select count(*) from field_data_field_s_opp_id" count(*)```
- Verify that there are fewer

# Affects 
- SoE (School of Engineering website)

# Associated Issues and/or People
## Related JIRA ticket(s)
https://stanfordits.atlassian.net/browse/SOE-2310
## Related PRs

## More Information
Currently the site is set to import opportunities every 15 minutes. I believe this is a mistake and should be removed.
Hence I **did not** export that setting into the feature.

Next steps:
- Merge into default branch
- Tag
- Pull to _Prod_
- Repeat steps to test

## Folks to notify
@kbrownell 


# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)